### PR TITLE
Add initial spec coverage for server spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+.byebug_history
 /.config
 /coverage/
 /InstalledFiles

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,6 @@ Style/FrozenStringLiteralComment:
 
 RSpec/FilePath:
   Enabled: false
+
+RSpec/ExampleLength:
+  Max: 10

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'celluloid-io', '~> 0.17'
 gem 'eventmachine', '~> 1.2'
 gem 'puma', '~> 3.9'
 gem 'sinatra', '~> 2.0'
+gem 'sinatra-contrib'
 gem 'slack-ruby-bot', '~> 0.10'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     airbrussh (1.2.0)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.3.0)
+    backports (3.8.0)
     byebug (9.0.6)
     capistrano (3.8.1)
       airbrussh (>= 1.0.0)
@@ -71,6 +72,7 @@ GEM
     i18n (0.8.4)
     json (2.1.0)
     minitest (5.10.2)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
     mustermann (1.0.0)
     net-scp (1.2.1)
@@ -125,6 +127,13 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.0)
       tilt (~> 2.0)
+    sinatra-contrib (2.0.0)
+      backports (>= 2.0)
+      multi_json
+      mustermann (~> 1.0)
+      rack-protection (= 2.0.0)
+      sinatra (= 2.0.0)
+      tilt (>= 1.3, < 3)
     slack-ruby-bot (0.10.3)
       hashie
       slack-ruby-client (>= 0.6.0)
@@ -179,6 +188,7 @@ DEPENDENCIES
   rubocop-rspec (~> 1.15.1)
   simplecov
   sinatra (~> 2.0)
+  sinatra-contrib
   slack-ruby-bot (~> 0.10)
   vcr (~> 3.0)
   webmock (~> 3.0)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,2 @@
+channels:
+  general: 'C04RMMCGX'

--- a/slack-library-bot/server.rb
+++ b/slack-library-bot/server.rb
@@ -5,18 +5,12 @@ module SlackLibraryBot
   # events from the real-time Slack API
   class Server < SlackRubyBot::Server
     on 'channel_created' do |client, data|
-      # general_channel = 'C04RMMCGX' general channel
-      general_channel = 'C62EZ1LLC' # bot-testing channel
+      general_channel = SlackLibraryBot::Web.settings.channels['general']
 
       new_channel_info = <<~CHANNEL_INFO
         Hi! <@#{data['channel']['creator']}> just created a new :slack: channel
         Check it out :point_right: <##{data['channel']['id']}>
       CHANNEL_INFO
-
-      # TODO: this isn't populated. why?
-      if data['channel']['purpose']
-        new_channel_info << "\n Purpose: #{data['channel']['purpose']}"
-      end
 
       client.say(channel: general_channel, text: new_channel_info)
     end

--- a/spec/fixtures/channel_created.json
+++ b/spec/fixtures/channel_created.json
@@ -1,0 +1,10 @@
+{
+  "type" : "channel_created",
+  "channel": {
+    "id": "C024BE91L",
+    "name": "fun-channel",
+    "created": "1360782804",
+    "creator": "U024BE7LH"
+  }
+}
+

--- a/spec/slack-library-bot/commands/ping_spec.rb
+++ b/spec/slack-library-bot/commands/ping_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
+require 'byebug'
 
-describe SlackLibraryBot::Commands::Ping do
+RSpec.describe SlackLibraryBot::Commands::Ping do
   def app
     SlackLibraryBot::Bot.instance
   end

--- a/spec/slack-library-bot/server_spec.rb
+++ b/spec/slack-library-bot/server_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'byebug'
+require 'json'
+
+RSpec.describe SlackLibraryBot::Server do
+  def app
+    SlackLibraryBot::Bot.instance
+  end
+
+  let(:data) { JSON.parse(File.read('spec/fixtures/channel_created.json')) }
+
+  describe 'register custom hooks' do
+    it 'has a channel_created hook' do
+      expect(app.hooks.handlers).to have_key('channel_created')
+    end
+  end
+
+  describe '#channel_created' do
+    it 'client receives #say to notify channel' do
+      client = instance_double('SlackRubyBot::Client')
+      channel_message = "Hi! <@U024BE7LH> just created a new :slack: channel\n"\
+                        "Check it out :point_right: <#C024BE91L>\n"
+      allow(client).to receive(:say)
+      app.hook_blocks['channel_created'].first.call(client, data)
+      expect(client).to have_received(:say).with(channel: 'C04RMMCGX',
+                                                 text: channel_message)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,9 +4,11 @@ require 'rack/test'
 require 'rspec'
 require 'slack-ruby-bot/rspec'
 require 'slack_library_bot'
+require 'web'
 require 'coveralls'
 
 ENV['RACK_ENV'] = 'test'
+ENV['SLACK_API_TOKEN'] = 'token'
 
 SimpleCov.formatter = Coveralls::SimpleCov::Formatter
 SimpleCov.start

--- a/web.rb
+++ b/web.rb
@@ -1,8 +1,13 @@
 require 'sinatra/base'
+require 'sinatra/config_file'
 
 module SlackLibraryBot
   # Wrapping bot in a Sinatra app. Primarily for ease of deployment
   class Web < Sinatra::Base
+    register Sinatra::ConfigFile
+
+    config_file 'config/settings.yml'
+
     get '/' do
       'Step right up, get your library automation here!'
     end


### PR DESCRIPTION
Also:

  * Add config file to make bot more re-usable for others
  * Add sinatra-contrib for config file
  * add channel_created.json fixture for server test
  * instance double used to mock out Client, but verify response